### PR TITLE
fix: retain `alignToPageBottom` property in FrameElement

### DIFF
--- a/src/elements/FrameElement.js
+++ b/src/elements/FrameElement.js
@@ -26,6 +26,7 @@ export default class FrameElement extends DocElement {
         this.borderWidth = '1';
 
         this.shrinkToContentHeight = false;
+        this.alignToPageBottom = false;
 
         this.spreadsheet_hide = false;
         this.spreadsheet_column = '';


### PR DESCRIPTION
Resolved an issue where the `alignToPageBottom` property was not preserved when saving and loading a layout.

The property was missing from the `FrameElement` class constructor, causing it to be set to `undefined` when `this.setInitialData(initialData)` was called. Updated the `FrameElement` class to include `alignToPageBottom` in its constructor, ensuring consistent behavior when loading saved layouts.